### PR TITLE
Switched to MySQL

### DIFF
--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -53,7 +53,8 @@ class Book extends Model
     public function scopeMinReviewsCount(Builder $query, int $count): Builder
     {
         // aggregate function on scope method above
-        return $query->where('reviews_count', '>=', $count);
+        // if switching to SQLite, change 'having' to 'where'
+        return $query->having('reviews_count', '>=', $count);
     }
 
     private function dateRangeFilter(Builder $query, $from = null, $to = null)

--- a/resources/views/books/index.blade.php
+++ b/resources/views/books/index.blade.php
@@ -7,7 +7,7 @@
         <input type="text" name="search" class="input h-10" placeholder="Search by Title" value="{{ request('search') }}">
         <input type="hidden" name="filter" value="{{ request('filter') }}">
         <button type="submit" class="btn h-10">Search</button>
-        <a href="{{ route('books.index', 'filter=latest') }}" class="btn h-10">Reset</a>
+        <a href="{{ route('books.index') }}" class="btn h-10">Reset</a>
     </form>
 
     <div class="filter-container mb-4 flex">


### PR DESCRIPTION
Switched the database designation in the .env file to MySQL instead of SQLite. Ran migrations. Had to change the 'where' clause in the scopeMinReviewsCount method to use 'having' because it is an aggregate sql function. MySQL requires 'having' while SQLite requires 'where'.